### PR TITLE
fix: make:bs時のパスが違いそうだったので修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ help:
 
 .PHONY: bs
 bs: # Bootstrap to start development.
-	@../scripts/bootstrap.sh
+	@./scripts/bootstrap.sh


### PR DESCRIPTION
## 対応したこと
ルートディレクトリで `make:bs` を実行したら以下のエラーで実行できなかったので修正しました。

```
❯ make bs
make: ../scripts/bootstrap.sh: No such file or directory
make: *** [bs] Error 1
```

## 確認してほしいこと
ルートディレクトリで `make:bs` が実行できるか
